### PR TITLE
Added Italian keymap missed license header and README change

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ NOTE: This project is NOT based on the spice-html5 prototype.
 
 - Full QXL Support of the entire spice protocol, including clipping, masking, scaling etc (accelerated mode)
 - Audio support, but only for raw audio samples, not for celt
-- Full KeyBoard support including English, Spanish and Catalan layouts
+- Full KeyBoard support including English, Spanish, Catalan and Italian layouts
 - Clipboard sharing support with customizble interface
 - Video streaming support with excellent performance even at 60fps FHD 1080p
 - Extremly high performant LZ decoder with sub <10ms for a FHD 1080P image

--- a/keymaps/keymapit.js
+++ b/keymaps/keymapit.js
@@ -1,3 +1,21 @@
+/*
+ eyeOS Spice Web Client
+ Copyright (c) 2015 M2R
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Affero General Public License version 3 as published by the
+ Free Software Foundation.
+ 
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ details.
+ 
+ You should have received a copy of the GNU Affero General Public License
+ version 3 along with this program in the file "LICENSE".  If not, see 
+ <http://www.gnu.org/licenses/agpl-3.0.txt>.
+ */
+
 // These tables map the js keyboard keys to the spice equivalent
 wdi.KeymapIT = function() {
 


### PR DESCRIPTION
Added italian keymap in README.
Added license header in keymaps/keymapit.js as required by https://github.com/eyeos/spice-web-client/issues/9
I was waiting for this:
https://lists.freedesktop.org/archives/spice-devel/2015-November/023313.html
But without any change or reply for months I added the license header atleast for keymapit.js as agplv3 without additions hoping is ok.
