### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Complete Spice Web Client written in HTML5 and Javascript 
+# Complete Spice Web Client written in HTML5 and Javascript 
 Full and complete implementation of the SPICE protocol (by Red Hat) written in HTML5 and JavaScript. It allows any standard HTML5-ready Web Browser to connect to remote 
 virtual sessions just by accessing a single URL.
 
@@ -24,14 +24,14 @@ NOTE: This project is NOT based on the spice-html5 prototype.
 - Spice authentication tokens support
 - Supports graphic live debugging the spice protocol and to replay packets to fix bugs
 
-##Missing features
+## Missing features
 
 There are some SPICE features still to be implemented, the most important ones are:
 
 - Celt or other audio codec
 - USB redirection (not possible at browser level, maybe with a plugin?)
 
-##Client System requirements
+## Client System requirements
 
 To get the best result we recommend at least 1GB of ram and at least two cores at 1,5ghz. 
 
@@ -39,14 +39,14 @@ It should work decently on 512mb of ram and 1ghz.
 
 We have made tests in raspberry pi 2 with very good results.
 
-##Network requirements
+## Network requirements
 
 Only Binary websockets are used to send and receive server data, so you should expect similar network requirements than SPICE itself.
 for a normal 1080p session the performance is very good up to 150-200ms of latency and 100kb/s bandwidth.
 
 The network consumption of a spice session depends a lot on the usage patterns.    
 
-##Performance
+## Performance
 
 Writing a web client for a protocol like spice is challenge because of the limited access to system resources like GPU and the way the javascript VM works.
 
@@ -58,7 +58,7 @@ for the javascript GC and refined all our canvas operations and all the entire s
 
 You should expect a near perfect experience if you meet the client requirements and the network requirements.
 
-##Browser support
+## Browser support
 
 We strongly recommend use the spice web client with Chromium/Chrome or Firefox, however it should work at least on:
 
@@ -68,7 +68,7 @@ We strongly recommend use the spice web client with Chromium/Chrome or Firefox, 
 - Edge
 
 
-##How to use it
+## How to use it
 
 In order to work you only need to provide the IP address of the websockets proxy and the port
 of the websockets proxy.
@@ -79,21 +79,21 @@ http://example.com/spice-web-client/index.html?host=IP_ADDRESS_OF_WEBSOCKIFY&por
 
 By doing this you will connect to the remote spice session and the resolution will be adapted to your browser viewport area.
 
-##Notes For linux sessions
+## Notes For linux sessions
 If you are planning to use this to connect to remote linux sessions you should consider disabling compositing on your desktop. The best performance is achieved with
 kde with compositing and visual effects disabled.
 
 Always install the spice-vdagent and xorg-qxl to get the best results and to have custom resolutions etc.
 
-##Notes For Windows sessions
+## Notes For Windows sessions
 
 Spice web client has a very good performance connecting to remote windows sessions. Always install the spice-agent package including the qxl video driver to get the best results and to have custom resolutions etc.
 
-##More information
+## More information
 
 For more information about the implementation or questions about roadmap etc contact Jose Carlos Norte (jcarlosn) at jose@eyeos.com
 
-##License
+## License
 
 Spice Web Client is distributed under the terms of the [MIT license](https://opensource.org/licenses/MIT).
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
