### PR TITLE
fixing flipped screen problem

### DIFF
--- a/lib/images/bitmap.js
+++ b/lib/images/bitmap.js
@@ -133,6 +133,7 @@ wdi.BMP2 = $.spcExtend(wdi.SpiceObject, {
 
 		} else {
 			if (type === wdi.SpiceBitmapFmt.SPICE_BITMAP_FMT_32BIT) {
+				topdown = true;
 				for (pos = 0; pos < size; pos += 4) {
 					b = data[pos];
 					data[pos] = data[pos + 2];


### PR DESCRIPTION
I noticed that the original spice5-html had this issue as well, and it was fixed in this patch:
https://cgit.freedesktop.org/~pgrunt/spice-html5/commit/?h=topdown

... which if I understood correctly, is just implementing a "topdown" (e.g. invert the coordinates for drawing) on a particular packet type/color depth, SPICE_SURFACE_FMT_32_xRGB.

Looking through the sources for the eyeOS web client, I found this in lib/images/bitmap.js:

```
                if(!topdown) {
                        ret = wdi.RasterOperation.flip(ret);
                }
```
Looking further up, we find the part of the code that deals with 32-bit color packets. It's called wdi.SpiceBitmapFmt.SPICE_BITMAP_FMT_32BIT here.
To fix it, I added a " topdown = true" statement. I've tested with a few of my own VMs that were experiencing this bug, especially in text mode. So far none have regressed.
